### PR TITLE
대회 정원 입력 페이지(headcount.tsx) 제작 및 유효성 검사

### DIFF
--- a/src/atoms/contestAtom.ts
+++ b/src/atoms/contestAtom.ts
@@ -1,0 +1,50 @@
+import { IEvent } from "@component/interfaces/eventInterface";
+import { atom, selector } from "recoil";
+
+export const contestEventAtom = atom<IEvent>({
+  key: "contestEvent",
+  default: {
+    팔씨름: false,
+    배구: false,
+    농구: false,
+    축구: false,
+    수영: false,
+    배드민턴: false,
+    태권도: false,
+    체조: false,
+    탁구: false,
+    테니스: false,
+    육상: false,
+    검도: false,
+    볼링: false,
+    야구: false,
+    족구: false,
+    합기도: false,
+    풋살: false,
+    골프: false,
+    요가: false,
+  },
+});
+
+export const contestEventCountAtom = atom<number>({
+  key: "contestEventCount",
+  default: 0,
+});
+
+export const contestEventSelector = selector({
+  key: "contestEventSelector",
+  get: ({ get }) =>
+    Object.keys(get(contestEventAtom)).find(
+      (key) => get(contestEventAtom)[key] === true
+    ),
+});
+
+export const contestMaxNumOfPlayers = atom<number>({
+  key: "contestMaxNumOfPlayers",
+  default: 9999,
+});
+
+export const contestMaxNumOfAudience = atom<number>({
+  key: "contestMaxNumOfAudience",
+  default: 9999,
+});

--- a/src/atoms/eventAtom.ts
+++ b/src/atoms/eventAtom.ts
@@ -26,45 +26,7 @@ export const eventAtom = atom<IEvent>({
   },
 });
 
-export const contestEventAtom = atom<IEvent>({
-  key: "contestEvent",
-  default: {
-    팔씨름: false,
-    배구: false,
-    농구: false,
-    축구: false,
-    수영: false,
-    배드민턴: false,
-    태권도: false,
-    체조: false,
-    탁구: false,
-    테니스: false,
-    육상: false,
-    검도: false,
-    볼링: false,
-    야구: false,
-    족구: false,
-    합기도: false,
-    풋살: false,
-    골프: false,
-    요가: false,
-  },
-});
-
 export const eventCountAtom = atom<number>({
   key: "eventCount",
   default: 0,
-});
-
-export const contestEventCountAtom = atom<number>({
-  key: "contestEventCount",
-  default: 0,
-});
-
-export const contestEventSelector = selector({
-  key: "contestEventSelector",
-  get: ({ get }) =>
-    Object.keys(get(contestEventAtom)).find(
-      (key) => get(contestEventAtom)[key] === true
-    ),
 });

--- a/src/interfaces/headcountInterface.ts
+++ b/src/interfaces/headcountInterface.ts
@@ -1,0 +1,4 @@
+export interface HeadCountForm {
+  numOfPlayers: number;
+  numOfAudience: number;
+}

--- a/src/pages/register/contest-info.tsx
+++ b/src/pages/register/contest-info.tsx
@@ -1,0 +1,25 @@
+import {
+  contestMaxNumOfAudience,
+  contestMaxNumOfPlayers,
+} from "@component/atoms/contestAtom";
+import Seo from "@component/components/Seo";
+import { PageWrapper } from "@component/components/container/container";
+import GoBackHeader from "@component/components/header/GoBackHeader";
+import React from "react";
+import { useRecoilValue } from "recoil";
+
+const ContestInfo = () => {
+  const numOfPlayers = useRecoilValue(contestMaxNumOfPlayers);
+  const numOfAudience = useRecoilValue(contestMaxNumOfAudience);
+
+  console.log("선수 정원 : ", numOfPlayers);
+  console.log("관람객 정원 : ", numOfAudience);
+  return (
+    <PageWrapper>
+      <Seo title="대회 정보 입력" />
+      <GoBackHeader title="대회 등록" />
+    </PageWrapper>
+  );
+};
+
+export default ContestInfo;

--- a/src/pages/register/event-select.tsx
+++ b/src/pages/register/event-select.tsx
@@ -1,8 +1,3 @@
-import {
-  contestEventAtom,
-  contestEventCountAtom,
-  contestEventSelector,
-} from "@component/atoms/eventAtom";
 import Seo from "@component/components/Seo";
 import { PageWrapper } from "@component/components/container/container";
 import GoBackHeader from "@component/components/header/GoBackHeader";
@@ -12,11 +7,15 @@ import { SelectArea, Text, TextArea } from "../auth/event-select.styles";
 import EventSelectButton from "@component/components/button/EventSelectButton";
 import Link from "next/link";
 import NavBar from "@component/components/navbar/NavBar";
+import {
+  contestEventAtom,
+  contestEventCountAtom,
+  contestEventSelector,
+} from "@component/atoms/contestAtom";
 
 const EventSelect = () => {
   const [contestEvents, setContestEvents] = useRecoilState(contestEventAtom);
   const [count, setCount] = useRecoilState(contestEventCountAtom);
-  const contestEvent = useRecoilValue(contestEventSelector);
   return (
     <PageWrapper>
       <Seo title="대회 종목 선택" />

--- a/src/pages/register/headcount.styles.ts
+++ b/src/pages/register/headcount.styles.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+export const SubText = styled.span`
+  color: #747474;
+  font-size: 16px;
+  font-weight: 400;
+`;
+
+export const Form = styled.form`
+  height: 75%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const InputWrapper = styled.div`
+  padding: 50px 20px;
+`;
+
+export const InputArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 30px;
+`;
+
+export const InputTitle = styled.h3`
+  color: #212121;
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 10px;
+`;
+
+export const Input = styled.input`
+  width: 335px;
+  height: 45px;
+  font-size: 14px;
+  font-weight: 400;
+  padding: 14px 15px;
+  color: #aeaeae;
+  background-color: #f9f9fa;
+  margin-bottom: 8px;
+`;
+
+export const ErrorMessage = styled.span`
+  font-size: 12px;
+  color: #ff002e;
+`;

--- a/src/pages/register/headcount.tsx
+++ b/src/pages/register/headcount.tsx
@@ -1,13 +1,92 @@
 import Seo from "@component/components/Seo";
 import { PageWrapper } from "@component/components/container/container";
 import GoBackHeader from "@component/components/header/GoBackHeader";
-import React from "react";
+import React, { useState } from "react";
+import { Text, TextArea } from "../auth/event-select.styles";
+import NavBar from "@component/components/navbar/NavBar";
+import * as S from "./headcount.styles";
+import { useForm } from "react-hook-form";
+import { useSetRecoilState } from "recoil";
+import {
+  contestMaxNumOfAudience,
+  contestMaxNumOfPlayers,
+} from "@component/atoms/contestAtom";
+import { useRouter } from "next/router";
+import { HeadCountForm } from "@component/interfaces/headcountInterface";
 
 const headcount = () => {
+  const router = useRouter();
+  const { register, handleSubmit, formState } = useForm<HeadCountForm>();
+  const setMaxNumOfPlayers = useSetRecoilState(contestMaxNumOfPlayers);
+  const setMaxNumOfAudience = useSetRecoilState(contestMaxNumOfAudience);
+  const [errorMsg, setErrorMsg] = useState<string | undefined>("");
+  const [errorMsgTwo, setErrorMsgTwo] = useState<string | undefined>("");
+
+  const onValid = (data: HeadCountForm) => {
+    if (data.numOfPlayers) {
+      setMaxNumOfPlayers(data.numOfPlayers);
+    }
+    if (data.numOfAudience) {
+      setMaxNumOfAudience(data.numOfAudience);
+    }
+    router.push("/register/contest-info");
+  };
+
+  const onInValid = () => {
+    if (formState.errors.numOfPlayers) {
+      setErrorMsg(formState.errors.numOfPlayers.message);
+    } else {
+      setErrorMsg("");
+    }
+    if (formState.errors.numOfAudience?.message) {
+      setErrorMsgTwo(formState.errors.numOfAudience?.message);
+    } else {
+      setErrorMsgTwo("");
+    }
+  };
+
   return (
     <PageWrapper>
-      <Seo title="대회 정원 설정" />
+      <Seo title="대회 정원 입력" />
       <GoBackHeader title="대회 등록" />
+      <TextArea>
+        <Text>대회 정원을</Text>
+        <Text>입력해주세요.</Text>
+        <S.SubText>정원에 제한이 없을 시 공백으로 남겨주세요.</S.SubText>
+      </TextArea>
+      <S.Form onSubmit={handleSubmit(onValid, onInValid)}>
+        <S.InputWrapper>
+          <S.InputArea>
+            <S.InputTitle>선수 정원</S.InputTitle>
+            <S.Input
+              {...register("numOfPlayers", {
+                validate: (value) =>
+                  value >= 0 ? true : "선수 정원은 0 이상의 수로 입력해주세요.",
+              })}
+              type="number"
+              placeholder="최대 선수 인원을 입력해주세요."
+            ></S.Input>
+            <S.ErrorMessage>{errorMsg === "" ? null : errorMsg}</S.ErrorMessage>
+          </S.InputArea>
+          <S.InputArea>
+            <S.InputTitle>관람객 정원</S.InputTitle>
+            <S.Input
+              {...register("numOfAudience", {
+                validate: (value) =>
+                  value >= 0
+                    ? true
+                    : "관람객 정원은 0 이상의 수로 입력해주세요.",
+              })}
+              type="number"
+              placeholder="최대 관람객 인원을 입력해주세요."
+            ></S.Input>
+            <S.ErrorMessage>
+              {errorMsgTwo === "" ? null : errorMsgTwo}
+            </S.ErrorMessage>
+          </S.InputArea>
+        </S.InputWrapper>
+        <NavBar active={true} />
+      </S.Form>
     </PageWrapper>
   );
 };


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역
- 대회 정원 입력 페이지(headcount.tsx) 제작
- 대회 정원 입력 유효성 검사 구현
- 대회 관련 전역 상태 값 별도 관리(contestAtom.ts)


<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리팩토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- 대회 개최 시 사용되는 전역 값들은 모두 atoms/contestAtom.ts 에서 관리됩니다.
- 대회 정원 미 입력시 기본 값은 9999로 설정하였습니다.

<br/><br/>